### PR TITLE
Fix typo in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ Rack::Timeout is not a solution to the problem of long-running requests, it's a 
 
 Basic Usage
 -----------
-
+c
 The following covers currently supported versions of Rails, Rack, Ruby, and Bundler. See the Compatibility section at the end for legacy versions.
 
 ### Rails apps
@@ -104,7 +104,7 @@ More detailed explanations of the issues surrounding timing out in ruby during I
 
 ### Timing Out Inherently Unsafe
 
-Raising mid-flight in stateful applications is inherently unsafe. A request can be aborted at any moment in the code flow, and the application cam be left in an inconsistent state. There's little way rack-timeout could be aware of ongoing state changes. Applications that rely on a set of globals (like class variables) or any other state that lives beyond a single request may find those left in an unexpected/inconsistent state after an aborted request. Some cleanup code might not have run, or only half of a set of related changes may have been applied.
+Raising mid-flight in stateful applications is inherently unsafe. A request can be aborted at any moment in the code flow, and the application can be left in an inconsistent state. There's little way rack-timeout could be aware of ongoing state changes. Applications that rely on a set of globals (like class variables) or any other state that lives beyond a single request may find those left in an unexpected/inconsistent state after an aborted request. Some cleanup code might not have run, or only half of a set of related changes may have been applied.
 
 A lot more can go wrong. An intricate explanation of the issue by JRuby's Charles Nutter can be found [here][broken-timeout].
 


### PR DESCRIPTION
I just changed `cam` -> to `can`, since that's clearly a typo.