### PR TITLE
Include CHANGELOG in gem

### DIFF
--- a/rack-timeout.gemspec
+++ b/rack-timeout.gemspec
@@ -6,6 +6,6 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'http://github.com/heroku/rack-timeout'
   spec.author      = 'Caio Chassot'
   spec.email       = 'caio@heroku.com'
-  spec.files       = Dir[*%w( MIT-LICENSE README.markdown lib/**/* )]
+  spec.files       = Dir[*%w( MIT-LICENSE CHANGELOG README.markdown lib/**/* )]
   spec.license     = 'MIT'
 end


### PR DESCRIPTION
Allows developers to to `bundle open rack-timeout` after a `bundle update` to see what's new etc.