### PR TITLE
change rails initialization to insert our middleware before Rack::Runtime

### DIFF
--- a/lib/rack/timeout/rails.rb
+++ b/lib/rack/timeout/rails.rb
@@ -1,5 +1,7 @@
 require_relative "base"
 
 class Rack::Timeout::Railtie < Rails::Railtie
-  initializer("rack-timeout.prepend") { |app| app.config.middleware.insert 0, Rack::Timeout }
+  initializer("rack-timeout.prepend") do |app|
+    app.config.middleware.insert_before Rack::Runtime, Rack::Timeout
+  end
 end


### PR DESCRIPTION
…, but after Rack::Lock, which caused issues, and after all the static file stuff, which kinda makes sense.