### PR TITLE
Rack::Timeout::Logger and related changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ master (eventual 0.3.0-beta)
 - instead of inserting middleware at position 0 for rails, insert before Rack::Runtime (which is right after Rack::Lock and the static file stuff)
 - reshuffle error types: RequestExpiryError is again a RuntimeError, and timeouts raise a RequestTimeoutException, an Exception, and not descending from Rack::Timeout::Error (see README for more)
 - don't insert middleware for rails in test environment
+- add convenience module Rack::Timeout::Logger (see README for more)
+- StageChangeLoggingObserver renamed to StageChangeLoggingObserver, works slightly differently too
 - file layout reorganization (see 6e82c276 for details)
 - CHANGELOG file is now in the gem (@dbackeus)
 

--- a/README.markdown
+++ b/README.markdown
@@ -214,7 +214,7 @@ Rack::Timeout.unregister_state_change_observer(:a_unique_name)
 ```
 
 
-rack-timeout's logging is implemented using an observer; see `Rack::Timeout::StateChangeLoggingObserver` in logger.rb for the implementation.
+rack-timeout's logging is implemented using an observer; see `Rack::Timeout::StateChangeLoggingObserver` in logging-observer.rb for the implementation.
 
 Custom observers might be used to do cleanup, store statistics on request length, timeouts, etc., and potentially do performance tuning on the fly.
 
@@ -228,18 +228,27 @@ Request state changes into `timed_out` and `expired` are logged at the `ERROR` l
 
 Rack::Timeout will try to use `Rails.logger` if present, otherwise it'll look for a logger in `env['rack.logger']`, and if neither are present, it'll create its own logger, either writing to `env['rack.errors']`, or to `$stderr` if the former is not set.
 
-A custom logger can be set via `Rack::Timeout::StateChangeLoggingObserver.logger`. This takes priority over the automatic logger detection:
-
-```ruby
-Rack::Timeout::StateChangeLoggingObserver.logger = Logger.new
-```
-
 When creating its own logger, rack-timeout will use a log level of `INFO`. Otherwise whatever log level is already set on the logger being used continues in effect.
 
-Logging is enabled by default if Rack::Timeout is loaded via the `rack-timeout` file (recommended), but can be removed by unregistering its observer:
+A custom logger can be set via `Rack::Timeout::Logger.logger`. This takes priority over the automatic logger detection:
 
 ```ruby
-Rack::Timeout.unregister_state_change_observer(:logger)
+Rack::Timeout::Logger.logger = Logger.new
+```
+
+There are helper setters that replace the logger:
+
+```ruby
+Rack::Timeout::Logger.device = $stderr
+Rack::Timeout::Logger.level  = Logger::INFO
+```
+
+Although each call replaces the logger, these can be use together and the final logger will retain both properties. (If only one is called, the defaults used above apply.)
+
+Logging is enabled by default, but can be removed with:
+
+```ruby
+Rack::Timeout::Logger.disable
 ```
 
 Each log line is a set of `key=value` pairs, containing the entries from the `env["rack-timeout.info"]` struct that are not `nil`. See the Request Lifetime section above for a description of each field. Note that while the values for `wait`, `timeout`, and `service` are stored internally as seconds, they are logged as milliseconds for readability.

--- a/README.markdown
+++ b/README.markdown
@@ -214,7 +214,7 @@ Rack::Timeout.unregister_state_change_observer(:a_unique_name)
 ```
 
 
-rack-timeout's logging is implemented using an observer; see `Rack::Timeout::StageChangeLoggingObserver` in logger.rb for the implementation.
+rack-timeout's logging is implemented using an observer; see `Rack::Timeout::StateChangeLoggingObserver` in logger.rb for the implementation.
 
 Custom observers might be used to do cleanup, store statistics on request length, timeouts, etc., and potentially do performance tuning on the fly.
 
@@ -228,10 +228,10 @@ Request state changes into `timed_out` and `expired` are logged at the `ERROR` l
 
 Rack::Timeout will try to use `Rails.logger` if present, otherwise it'll look for a logger in `env['rack.logger']`, and if neither are present, it'll create its own logger, either writing to `env['rack.errors']`, or to `$stderr` if the former is not set.
 
-A custom logger can be set via `Rack::Timeout::StageChangeLoggingObserver.logger`. This takes priority over the automatic logger detection:
+A custom logger can be set via `Rack::Timeout::StateChangeLoggingObserver.logger`. This takes priority over the automatic logger detection:
 
 ```ruby
-Rack::Timeout::StageChangeLoggingObserver.logger = Logger.new
+Rack::Timeout::StateChangeLoggingObserver.logger = Logger.new
 ```
 
 When creating its own logger, rack-timeout will use a log level of `INFO`. Otherwise whatever log level is already set on the logger being used continues in effect.

--- a/lib/rack/timeout/base.rb
+++ b/lib/rack/timeout/base.rb
@@ -1,4 +1,4 @@
 require_relative "core"
-require_relative "logging-observer"
+require_relative "logger"
 
-Rack::Timeout::StateChangeLoggingObserver.register!
+Rack::Timeout::Logger.init

--- a/lib/rack/timeout/base.rb
+++ b/lib/rack/timeout/base.rb
@@ -1,4 +1,4 @@
 require_relative "core"
 require_relative "logging-observer"
 
-Rack::Timeout::StageChangeLoggingObserver.register!
+Rack::Timeout::StateChangeLoggingObserver.register!

--- a/lib/rack/timeout/logger.rb
+++ b/lib/rack/timeout/logger.rb
@@ -1,0 +1,39 @@
+require "logger"
+require_relative "core"
+require_relative "logging-observer"
+
+module Rack::Timeout::Logger
+  extend self
+  attr :device, :level, :logger
+
+  def device=(new_device)
+    update(new_device, level)
+  end
+
+  def level=(new_level)
+    update(device, new_level)
+  end
+
+  def logger=(new_logger)
+    @logger = @observer.logger = new_logger
+  end
+
+  def init
+    @observer = ::Rack::Timeout::StateChangeLoggingObserver.new
+    ::Rack::Timeout.register_state_change_observer(:logger, &@observer.callback)
+    @inited = true
+  end
+
+  def disable
+    @observer, @logger, @level, @device, @inited = nil
+    ::Rack::Timeout.unregister_state_change_observer(:logger)
+  end
+
+  def update(new_device, new_level)
+    init unless @inited
+    @device     = new_device || $stderr
+    @level      = new_level  || ::Logger::INFO
+    self.logger = ::Rack::Timeout::StateChangeLoggingObserver.mk_logger(device, level)
+  end
+
+end

--- a/lib/rack/timeout/logging-observer.rb
+++ b/lib/rack/timeout/logging-observer.rb
@@ -1,59 +1,57 @@
 require "logger"
 require_relative "core"
 
-class Rack::Timeout
-  class StateChangeLoggingObserver
-    STATE_LOG_LEVEL = { :expired   => :error,
-                        :ready     => :info,
-                        :active    => :debug,
-                        :timed_out => :error,
-                        :completed => :info,
-                      }
+class Rack::Timeout::StateChangeLoggingObserver
+  STATE_LOG_LEVEL = { :expired   => :error,
+                      :ready     => :info,
+                      :active    => :debug,
+                      :timed_out => :error,
+                      :completed => :info,
+                    }
 
-    # creates a logger and registers for state change notifications in Rack::Timeout
-    def self.register!(logger = nil)
-      new.register!(logger)
-    end
-
-    # registers for state change notifications in Rack::Timeout (or other explicit target (potentially useful for testing))
-    def register!(logger = nil, target = ::Rack::Timeout)
-      @logger = logger
-      target.register_state_change_observer(:logger, &method(:log_state_change))
-    end
-
-    SIMPLE_FORMATTER = ->(severity, timestamp, progname, msg) { "#{msg} at=#{severity.downcase}\n" }
-    def self.mk_logger(device, level = ::Logger::INFO)
-      ::Logger.new(device).tap do |logger|
-        logger.level     = level
-        logger.formatter = SIMPLE_FORMATTER
-      end
-    end
-
-    class << self
-      attr_accessor :logger
-    end
-    def logger(env = nil)
-      self.class.logger ||
-        (defined?(::Rails) && Rails.logger) ||
-        (env && !env["rack.logger"].is_a?(::Rack::NullLogger) && env["rack.logger"]) ||
-        (env && env["rack.errors"] && self.class.mk_logger(env["rack.errors"]))      ||
-        (@fallback_logger ||= self.class.mk_logger($stderr))
-    end
-
-    # generates the actual log string
-    def log_state_change(env)
-      info = env[ENV_INFO_KEY]
-      level = STATE_LOG_LEVEL[info.state]
-      logger(env).send(level) do
-        s  = "source=rack-timeout"
-        s << " id="      << info.id           if info.id
-        s << " wait="    << info.ms(:wait)    if info.wait
-        s << " timeout=" << info.ms(:timeout) if info.timeout
-        s << " service=" << info.ms(:service) if info.service
-        s << " state="   << info.state.to_s   if info.state
-        s
-      end
-    end
-
+  # creates a logger and registers for state change notifications in Rack::Timeout
+  def self.register!(logger = nil)
+    new.register!(logger)
   end
+
+  # registers for state change notifications in Rack::Timeout (or other explicit target (potentially useful for testing))
+  def register!(logger = nil, target = ::Rack::Timeout)
+    @logger = logger
+    target.register_state_change_observer(:logger, &method(:log_state_change))
+  end
+
+  SIMPLE_FORMATTER = ->(severity, timestamp, progname, msg) { "#{msg} at=#{severity.downcase}\n" }
+  def self.mk_logger(device, level = ::Logger::INFO)
+    ::Logger.new(device).tap do |logger|
+      logger.level     = level
+      logger.formatter = SIMPLE_FORMATTER
+    end
+  end
+
+  class << self
+    attr_accessor :logger
+  end
+  def logger(env = nil)
+    self.class.logger ||
+      (defined?(::Rails) && Rails.logger) ||
+      (env && !env["rack.logger"].is_a?(::Rack::NullLogger) && env["rack.logger"]) ||
+      (env && env["rack.errors"] && self.class.mk_logger(env["rack.errors"]))      ||
+      (@fallback_logger ||= self.class.mk_logger($stderr))
+  end
+
+  # generates the actual log string
+  def log_state_change(env)
+    info = env[::Rack::Timeout::ENV_INFO_KEY]
+    level = STATE_LOG_LEVEL[info.state]
+    logger(env).send(level) do
+      s  = "source=rack-timeout"
+      s << " id="      << info.id           if info.id
+      s << " wait="    << info.ms(:wait)    if info.wait
+      s << " timeout=" << info.ms(:timeout) if info.timeout
+      s << " service=" << info.ms(:service) if info.service
+      s << " state="   << info.state.to_s   if info.state
+      s
+    end
+  end
+
 end

--- a/lib/rack/timeout/logging-observer.rb
+++ b/lib/rack/timeout/logging-observer.rb
@@ -2,7 +2,7 @@ require "logger"
 require_relative "core"
 
 class Rack::Timeout
-  class StageChangeLoggingObserver
+  class StateChangeLoggingObserver
     STATE_LOG_LEVEL = { :expired   => :error,
                         :ready     => :info,
                         :active    => :debug,


### PR DESCRIPTION
Basically makes customizing logging options a lot simpler. No need to expose StateChangeLoggingObserver details.