### PR TITLE
patch up rollbar to group timeouts for the same url

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ master (eventual 0.3.0-beta)
 - StageChangeLoggingObserver renamed to StageChangeLoggingObserver, works slightly differently too
 - file layout reorganization (see 6e82c276 for details)
 - CHANGELOG file is now in the gem (@dbackeus)
+- add optional and experimental support for grouping errors by url under rollbar. see "rack/timeout/rollbar" for usage
 
 0.2.4
 =====

--- a/lib/rack/timeout/rollbar.rb
+++ b/lib/rack/timeout/rollbar.rb
@@ -3,6 +3,8 @@ require_relative "core"
 # Groups timeout exceptions in rollbar by exception class, http method, and url.
 # Usage: after requiring rollbar, call:
 #   require "rack/timeout/rollbar"
+#
+# This is somewhat experimental and very lightly tested.
 
 module Rack::Timeout::Rollbar
   def build_payload(level, message, exception, extra)

--- a/lib/rack/timeout/rollbar.rb
+++ b/lib/rack/timeout/rollbar.rb
@@ -1,0 +1,29 @@
+require_relative "core"
+
+# Groups timeout exceptions in rollbar by exception class, http method, and url.
+# Usage: after requiring rollbar, call:
+#   require "rack/timeout/rollbar"
+
+module Rack::Timeout::Rollbar
+  def build_payload(level, message, exception, extra)
+    payload = super(level, message, exception, extra)
+
+    return payload unless exception.is_a? ::Rack::Timeout::ExceptionWithEnv
+    return payload unless payload.respond_to? :[]
+
+    data = payload["data"]
+    return data unless data.respond_to? :[]=
+
+    request = ::Rack::Request.new(exception.env)
+
+    data["fingerprint"] = [
+      exception.class.name,
+      request.request_method,
+      request.fullpath
+      ].join(" ")
+
+    return payload
+  end
+end
+
+::Rollbar::Notifier.prepend ::Rack::Timeout::Rollbar


### PR DESCRIPTION
Usage: after requiring rollbar, call:

    require "rack/timeout/rollbar"