### PR TITLE
Reduce object creation

### DIFF
--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -21,6 +21,7 @@ module Rack
       include ExceptionWithEnv
     end
 
+    REQUEST_TIME_FORMAT = '%.fms'.freeze
     RequestDetails = Struct.new(
       :id,        # a unique identifier for the request. informative-only.
       :wait,      # seconds the request spent in the web server before being serviced by rack
@@ -29,7 +30,7 @@ module Rack
       :state,     # the request's current state, see below:
     ) {
       def ms(k)   # helper method used for formatting values in milliseconds
-        "%.fms" % (self[k] * 1000) if self[k]
+        REQUEST_TIME_FORMAT % (self[k] * 1000) if self[k]
       end
     }
     VALID_STATES = [
@@ -39,7 +40,7 @@ module Rack
       :timed_out, # This request has run for too long and we're raising a timeout error in it
       :completed, # We're done with this request (also set after having timed out a request)
       ]
-    ENV_INFO_KEY = "rack-timeout.info" # key under which each request's RequestDetails instance is stored in its env.
+    ENV_INFO_KEY = "rack-timeout.info".freeze # key under which each request's RequestDetails instance is stored in its env.
 
     # helper methods to setup getter/setters for timeout properties. Ensure they're always positive numbers or false. When set to false (or 0), their behaviour is disabled.
     class << self
@@ -156,8 +157,9 @@ module Rack
 
     # This method determines if a body is present. requests with a body (generally POST, PUT) can have a lengthy body which may have taken a while to be received by the web server, inflating their computed wait time. This in turn could lead to unwanted expirations. See wait_overtime property as a way to overcome those.
     # This is a code extraction for readability, this method is only called from a single point.
+    CHUNKED = 'chunked'.freeze
     def self._request_has_body?(env)
-      return true  if env["HTTP_TRANSFER_ENCODING"] == "chunked"
+      return true  if env["HTTP_TRANSFER_ENCODING"] == CHUNKED
       return false if env["CONTENT_LENGTH"].nil?
       return false if env["CONTENT_LENGTH"].to_i.zero?
       true


### PR DESCRIPTION
As an exercise after seeing rack-timeout in the top 10 of gems allocating memory and objects for a particular request, I did a quick pass at optimizing some of its memory usage and found some areas of improvement. However, in practice in an actual app, I didn't find a speed boost or significant effect on memory. I thought I would submit it for consideration anyway.

This reduced memory allocation and object creation during the rack timeout middleware, especially the logging methods. 

Before patch:

                 ips   630.000  i/100ms
                 ips      6.311k (± 6.3%) i/s -     31.500k

allocated objects by gem after 100 requests:

      8762  rack-timeout-0.3.0.pre.beta.2

After patch:

                 ips   697.000  i/100ms
                 ips      7.096k (± 5.2%) i/s -     35.547k

allocated objects by gem after 100 requests:

      6945  rack-timeout-c0d1ef46850b

Benchmarking performed by adding to an existing app (inspired by an approach used on omniauth (https://github.com/intridea/omniauth/pull/775):

```ruby
namespace :perf do
  task :setup do
    require 'rack-timeout'
    require 'rack/test'
    app = Rack::Builder.new do |b|
      b.use Rack::Timeout
      b.run lambda { |_env| [200, {}, ['Not Found']] }
    end.to_app
    @app = Rack::MockRequest.new(app)

    def call_app(path = ENV['GET_PATH'] || '/')
      result = @app.get(path)
      fail "Did not succeed #{result.body}" unless result.status == 200
      result
    end
  end

  task :ips => :setup do
    require 'benchmark/ips'
    Benchmark.ips do |x|
      x.report('ips') { call_app }
    end
  end

  task :mem => :setup do
    require 'memory_profiler'
    num = Integer(ENV['CNT'] || 1)
    report = MemoryProfiler.report do
      num.times { call_app }
    end
    report.pretty_print
  end
end
```