### PR TITLE
Allow setting of options at `use` time

### DIFF
--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -71,8 +71,12 @@ module Rack
       @service_past_wait = false          # we default to false under the assumption that the router would drop a request that's not responded within wait_timeout, thus being there no point in servicing beyond seconds_service_left (see code further down) up until service_timeout.
     end
 
-    def initialize(app)
+    def initialize(app, options = {})
       @app = app
+      options.each do |attr, value|
+        writer = "#{attr}=".to_sym
+        self.class.send(writer, value) if self.class.respond_to? writer
+      end
     end
 
 


### PR DESCRIPTION
A simple tweak to allow non-Rails applications to do something like:

```ruby
use Rack::Timeout, :timeout => 30
```

Instead of:

```ruby
use Rack::Timeout
Rack::Timeout.timeout = 30
```

I shied away from calling `set_property_value` directly because (after a light reading of the code) it seems it would allow a user to set arbitrary class instance variables. This technique respects the defined `attr_writer` methods. 