### PR TITLE
Ensure state is marked as completed if exception is thrown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -163,9 +163,9 @@ The value of that entry is an instance of `Rack::Timeout::RequestDetails`, which
 
     *   `active` (`DEBUG`): the request is being actively processed in the application thread. This is signaled repeatedly every ~1s until the request completes or times out.
 
-    *   `timed_out` (`ERROR`): the request ran for longer than the determined timeout and was aborted. `Rack::Timeout::RequestTimeoutException` is raised in the application when this occurs. If this exception gets caught, handled, and not re-raised in the app or framework (which will generally happen with Rails and Sinatra), this state will not be final, `completed` will be set after the framework is done with it. (If the exception does bubble up, it's caught by rack-timeout and re-raised as `Rack::Timeout::RequestTimeoutError`, which descends from RuntimeError.)
+    *   `timed_out` (`ERROR`): the request ran for longer than the determined timeout and was aborted. `Rack::Timeout::RequestTimeoutException` is raised in the application when this occurs. This state is not the final one, `completed` will be set after the framework is done with it. (If the exception does bubble up, it's caught by rack-timeout and re-raised as `Rack::Timeout::RequestTimeoutError`, which descends from RuntimeError.)
 
-    *   `completed` (`INFO`): the request completed and Rack::Timeout is done with it. This does not mean the request completed *successfully*. Rack::Timeout does not concern itself with that. As mentioned just above, a timed out request may still end up with a `completed` state if the framework has dealt with the timeout exception.
+    *   `completed` (`INFO`): the request completed and Rack::Timeout is done with it. This does not mean the request completed *successfully*. Rack::Timeout does not concern itself with that. As mentioned just above, a timed out request will still end up with a `completed` state.
 
 
 Errors

--- a/lib/rack/timeout/core.rb
+++ b/lib/rack/timeout/core.rb
@@ -114,23 +114,20 @@ module Rack
         info.service = Time.now - time_started_service      # update service time
         RT._set_state! env, status                          # update status
       }
+      heartbeat_event = RT::Scheduler.run_every(1) { register_state_change.call :active }  # start updating every second while active; if log level is debug, this will log every sec
 
-      begin
-        heartbeat_event = RT::Scheduler.run_every(1) { register_state_change.call :active }  # start updating every second while active; if log level is debug, this will log every sec
+      timeout = RT::Scheduler::Timeout.new do |app_thread|  # creates a timeout instance responsible for timing out the request. the given block runs if timed out
+        register_state_change.call :timed_out
+        app_thread.raise(RequestTimeoutException.new(env), "Request #{"waited #{info.ms(:wait)}, then " if info.wait}ran for longer than #{info.ms(:timeout)}")
+      end
 
-        timeout = RT::Scheduler::Timeout.new do |app_thread|  # creates a timeout instance responsible for timing out the request. the given block runs if timed out
-          register_state_change.call :timed_out
-          app_thread.raise(RequestTimeoutException.new(env), "Request #{"waited #{info.ms(:wait)}, then " if info.wait}ran for longer than #{info.ms(:timeout)}")
+      response = timeout.timeout(info.timeout) do           # perform request with timeout
+        begin  @app.call(env)                               # boom, send request down the middleware chain
+        rescue RequestTimeoutException => e                 # will actually hardly ever get to this point because frameworks tend to catch this. see README for more
+          raise RequestTimeoutError.new(env), e.message, e.backtrace  # but in case it does get here, re-raise RequestTimeoutException as RequestTimeoutError
+        ensure
+          register_state_change.call :completed
         end
-
-        response = timeout.timeout(info.timeout) do           # perform request with timeout
-          begin  @app.call(env)                               # boom, send request down the middleware chain
-          rescue RequestTimeoutException => e                 # will actually hardly ever get to this point because frameworks tend to catch this. see README for more
-            raise RequestTimeoutError.new(env), e.message, e.backtrace  # but in case it does get here, re-raise RequestTimeoutException as RequestTimeoutError
-          end
-        end
-      ensure
-        register_state_change.call :completed
       end
 
       response


### PR DESCRIPTION
If `config.action_dispatch.show_exceptions = false` is set and an exception is thrown (not a timeout one), it gets through rack-timeout middleware making hearbeat event logged for failed request forever. E.g.
```
source=rack-timeout id=2842eb4a27a13df8091a0f1aeafb791b timeout=3000ms service=25001ms state=active
source=rack-timeout id=2842eb4a27a13df8091a0f1aeafb791b timeout=3000ms service=26001ms state=active
source=rack-timeout id=2842eb4a27a13df8091a0f1aeafb791b timeout=3000ms service=27001ms state=active
```
This PR ensures all requests are marked as completed on middleware's `call` is completed.