### PR TITLE
Removing broken shellycloud.com link from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -137,8 +137,6 @@ At the moment rack-timeout does not try to address this issue. As a fail-safe ag
 More detailed explanations of the issues surrounding timing out in ruby during IO blocks can be found at:
 
 - http://redgetan.cc/understanding-timeouts-in-cruby/
-- https://shellycloud.com/blog/2013/06/the-pesky-problem-of-freezing-thin
-
 
 ### Timing Out Inherently Unsafe
 


### PR DESCRIPTION
The "The pesky problem of freezing thin servers" article is no longer available at that URL so I removed it. Alternatively, an archived copy of the article can be found here:
https://web.archive.org/web/20130731064820/http://blog.shellycloud.com/2013/06/the-pesky-problem-of-freezing-thin.html?