### PR TITLE
Update deprecated option config

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,7 +55,9 @@ require "rack-timeout"
 
 # Call as early as possible so rack-timeout runs before all other middleware.
 # Setting service_timeout is recommended. If omitted, defaults to 15 seconds.
-use Rack::Timeout, service_timeout: 5
+use Rack::Timeout do |config|
+  config.timeout = 5
+end
 ```
 
 


### PR DESCRIPTION
I'm using `rack-timeout` with Sinatra (1.4.6) and got warnings because the _old_ way to set the config options is deprecated.
