### PR TITLE
Docs: In changelog, identify breaking changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,16 @@
 0.5.0
 =====
+
+Breaking Changes
+
+- Remove Rollbar module (#124)
+- Remove legacy class setters (#125)
+
+Other
+
 - Add support to configure via environment variables (#105)
 - Adds support for ActionDispatch::RequestId generated request ids (#115)
 - Changes uuid format to proper uuid (#115)
-- Remove Rollbar module (#124)
-- Remove legacy class setters (#125)
 
 0.4.2
 =====


### PR DESCRIPTION
To make upgrading easier for people, identify breaking changes