### PR TITLE
Actually comment the comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ require "rack-timeout"
 
 # Call as early as possible so rack-timeout runs before all other middleware.
 # Setting service_timeout or `RACK_TIMEOUT_SERVICE_TIMEOUT` environment
-variable is recommended. If omitted, defaults to 15 seconds.
+# variable is recommended. If omitted, defaults to 15 seconds.
 use Rack::Timeout, service_timeout: 5
 ```
 


### PR DESCRIPTION
This comment was not prepended with a `#`.